### PR TITLE
Feature/set logger

### DIFF
--- a/log.lua
+++ b/log.lua
@@ -18,16 +18,16 @@ local startuploglevel = os and os.getenv
 
 local currentloglevel = startuploglevel
 
-local function defaultlogger(from, level, ...)
+local function defaultlogger(opts, ...)
   if not currentloglevel then return end
-  if level >= currentloglevel then
+  if opts.level >= currentloglevel then
     local components = {}
     for _, v in ipairs({...}) do table.insert(components,tostring(v)) end
 
     print(string.format(
       "[%s]%s %s",
-      loglevels[level],
-      from and "("..from..")" or "",
+      loglevels[opts.level],
+      opts.from and "("..opts.from..")" or "",
       table.concat(components, "\t")
     ))
   end
@@ -35,31 +35,31 @@ end
 local currentlogger = defaultlogger -- TODO: allow overriding
 
 function log.print(...)
-  currentlogger(nil, revlevels.PRINT, ...)
+  currentlogger({level = revlevels.PRINT}, ...)
 end
 
 function log.fatal(...)
-  currentlogger(nil, revlevels.FATAL, ...)
+  currentlogger({level = revlevels.FATAL}, ...)
 end
 
 function log.error(...)
-  currentlogger(nil, revlevels.ERROR, ...)
+  currentlogger({level = revlevels.ERROR}, ...)
 end
 
 function log.warn(...)
-  currentlogger(nil, revlevels.WARN, ...)
+  currentlogger({level = revlevels.WARN}, ...)
 end
 
 function log.info(...)
-  currentlogger(nil, revlevels.INFO, ...)
+  currentlogger({level = revlevels.INFO}, ...)
 end
 
 function log.debug(...)
-  currentlogger(nil, revlevels.DEBUG, ...)
+  currentlogger({level = revlevels.DEBUG}, ...)
 end
 
 function log.trace(...)
-  currentlogger(nil, revlevels.TRACE, ...)
+  currentlogger({level = revlevels.TRACE}, ...)
 end
 
 function log.setLogLevel(level)

--- a/log.lua
+++ b/log.lua
@@ -66,4 +66,8 @@ function log.setLogLevel(level)
   currentloglevel = level
 end
 
+function log.setLogger(logger)
+  currentlogger = logger
+end
+
 return log

--- a/log.lua
+++ b/log.lua
@@ -15,7 +15,7 @@ for i, level in ipairs(loglevels) do revlevels[level] = i end
 
 local startuploglevel = os and os.getenv
                            and revlevels[string.upper(os.getenv("LUALOG") or "")]
--- TODO: provide interfaces to dynamically set log level
+
 local currentloglevel = startuploglevel
 
 local function defaultlogger(from, level, ...)
@@ -60,6 +60,10 @@ end
 
 function log.trace(...)
   currentlogger(nil, revlevels.TRACE, ...)
+end
+
+function log.setLogLevel(level)
+  currentloglevel = level
 end
 
 return log


### PR DESCRIPTION
This PR is comprised of 3 commits

First, adds an interface for setting the internal log level for this modules.

Second, adds an interface for setting the internal logger for this module.

Third, is an attempt to solidify the "logger" api by combining the first 2 arguments of `defaultLogger` into a single table. This makes the api `function(opts: {level: string, from: string?}, ...)`, this has 2 benefits, 1 it simplifies the general interface and 2 it allows for future enhancement w/o causing a breaking change. That being said, this might be entirely unnecessary since the `logger` could capture its own context to report w/o leaking this abstraction. 


Another alternative I considered instead of adding `set*` methods is exposing the logger and level via properties on the module table (`log`) which would allow for things like

```lua
local log = require "log"
--- Use a cli flag to driver the log level
if string:match(table.concat(..., " "), "--verbose") then
  log.currentLogLevel = "TRACE"
end
--- prepend all log messages witht he current file
local defaultLogger = log.currentLogger
local me = debug.getinfo(1, "S").short_source
log.currentLogger = function(opts, ...)
  defaultLogger(opts, me, ...)
end
```
